### PR TITLE
NEW class DateNone to don't raise error if a read field Date is '           '

### DIFF
--- a/retrofix/fields.py
+++ b/retrofix/fields.py
@@ -36,7 +36,7 @@ from .exception import RetrofixException
 
 __all__ = ['Field', 'Char', 'Const', 'Account', 'Number', 'Numeric', 'Integer',
     'Date', 'Selection', 'Boolean', 'SIGN_DEFAULT', 'SIGN_12', 'SIGN_N',
-    'SIGN_POSITIVE', 'BOOLEAN_01', 'BOOLEAN_12', 'BOOLEAN_X', 'BOOLEAN_W1']
+    'SIGN_POSITIVE', 'BOOLEAN_01', 'BOOLEAN_12', 'BOOLEAN_X', 'BOOLEAN_W1', 'DateNone']
 
 
 class Field(object):
@@ -227,6 +227,23 @@ class Date(Field):
     def set(self, value):
         assert value, datetime
         return super(Date, self).set(value)
+
+
+class DateNone(Date):
+    def __init__(self, pattern):
+        Date.__init__(self, pattern)
+        #super(Date, self).__init__(pattern)
+        #self._pattern = pattern
+
+    def set_from_file(self, value):
+        if value == '0' * len(value) or value == ' ' * len(value):
+            return
+        try:
+            return datetime.strptime(value, self._pattern)
+        except ValueError:
+            raise RetrofixException('Invalid date value "%s" does not '
+                    'match pattern "%s" in field "%s"' % (value,
+                    self._pattern, self._name))
 
 
 class Selection(Char):

--- a/retrofix/fields.py
+++ b/retrofix/fields.py
@@ -232,8 +232,6 @@ class Date(Field):
 class DateNone(Date):
     def __init__(self, pattern):
         Date.__init__(self, pattern)
-        #super(Date, self).__init__(pattern)
-        #self._pattern = pattern
 
     def set_from_file(self, value):
         if value == '0' * len(value) or value == ' ' * len(value):

--- a/retrofix/fields.py
+++ b/retrofix/fields.py
@@ -243,6 +243,13 @@ class DateNone(Date):
                     'match pattern "%s" in field "%s"' % (value,
                     self._pattern, self._name))
 
+    def get_for_file(self, value):
+        if value is None:
+            return False
+        else:
+            res = datetime.strftime(value, self._pattern)
+        return super(Date, self).get_for_file(res)
+
 
 class Selection(Char):
     def __init__(self, selection):


### PR DESCRIPTION
### Description
All info are in issue #6 
### Tasks
- [x] Created new inherited class DateNone from Date class in **fields.py**
- [x] Redefined **set_from_file** method to don't trigger void reads '        '
- [x] Add class name to _all list

Closes #6 